### PR TITLE
Fixes to compile on Rolling.

### DIFF
--- a/ros_babel_fish/CMakeLists.txt
+++ b/ros_babel_fish/CMakeLists.txt
@@ -131,7 +131,6 @@ if (BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(ament_cmake_gtest REQUIRED)
-  find_package(action_tutorials_interfaces REQUIRED)
   find_package(example_interfaces REQUIRED)
   find_package(geometry_msgs REQUIRED)
   find_package(ros_babel_fish_test_msgs REQUIRED)
@@ -154,7 +153,7 @@ if (BUILD_TESTING)
   target_link_libraries(test_service_client ${PROJECT_NAME})
 
   ament_add_gtest(test_action_client test/action_client.cpp)
-  ament_target_dependencies(test_action_client action_tutorials_interfaces example_interfaces ros_babel_fish_test_msgs)
+  ament_target_dependencies(test_action_client example_interfaces example_interfaces ros_babel_fish_test_msgs)
   target_link_libraries(test_action_client ${PROJECT_NAME})
 endif ()
 

--- a/ros_babel_fish/CMakeLists.txt
+++ b/ros_babel_fish/CMakeLists.txt
@@ -153,7 +153,7 @@ if (BUILD_TESTING)
   target_link_libraries(test_service_client ${PROJECT_NAME})
 
   ament_add_gtest(test_action_client test/action_client.cpp)
-  ament_target_dependencies(test_action_client example_interfaces example_interfaces ros_babel_fish_test_msgs)
+  ament_target_dependencies(test_action_client example_interfaces ros_babel_fish_test_msgs)
   target_link_libraries(test_action_client ${PROJECT_NAME})
 endif ()
 

--- a/ros_babel_fish/examples/action_client.cpp
+++ b/ros_babel_fish/examples/action_client.cpp
@@ -14,8 +14,8 @@ int main( int argc, char **argv )
   auto node = rclcpp::Node::make_shared( "action_client" );
   std::thread spin_thread( [node]() { rclcpp::spin( node ); } );
   BabelFish fish;
-  auto client = fish.create_action_client( *node, "fibonacci",
-                                           "action_tutorials_interfaces/action/Fibonacci" );
+  auto client =
+      fish.create_action_client( *node, "fibonacci", "example_interfaces/action/Fibonacci" );
 
   RCLCPP_INFO( node->get_logger(), "Waiting for server to come up." );
   if ( !client->wait_for_action_server( 10s ) ) {

--- a/ros_babel_fish/include/ros_babel_fish/detail/any_service_callback.hpp
+++ b/ros_babel_fish/include/ros_babel_fish/detail/any_service_callback.hpp
@@ -57,7 +57,7 @@ public:
                  const std::shared_ptr<rmw_request_id_t> &request_header,
                  std::shared_ptr<CompoundMessage> request, std::shared_ptr<CompoundMessage> response )
   {
-    TRACEPOINT( callback_start, static_cast<const void *>( this ), false );
+    TRACETOOLS_TRACEPOINT( callback_start, static_cast<const void *>( this ), false );
     if ( std::holds_alternative<SharedPtrCallback>( callback_ ) ) {
       (void)request_header;
       const auto &cb = std::get<SharedPtrCallback>( callback_ );
@@ -72,7 +72,7 @@ public:
       const auto &cb = std::get<SharedPtrDeferResponseCallbackWithServiceHandle>( callback_ );
       cb( service_handle, request_header, std::move( request ) );
     }
-    TRACEPOINT( callback_end, static_cast<const void *>( this ) );
+    TRACETOOLS_TRACEPOINT( callback_end, static_cast<const void *>( this ) );
   }
 
   void register_callback_for_tracing()
@@ -80,8 +80,8 @@ public:
 #ifndef TRACETOOLS_DISABLED
     std::visit(
         [this]( auto &&arg ) {
-          TRACEPOINT( rclcpp_callback_register, static_cast<const void *>( this ),
-                      tracetools::get_symbol( arg ) );
+          TRACETOOLS_TRACEPOINT( rclcpp_callback_register, static_cast<const void *>( this ),
+                                 tracetools::get_symbol( arg ) );
         },
         callback_ );
 #endif // TRACETOOLS_DISABLED

--- a/ros_babel_fish/package.xml
+++ b/ros_babel_fish/package.xml
@@ -22,16 +22,15 @@
   <depend>rosidl_runtime_cpp</depend>
   <depend>rosidl_typesupport_cpp</depend>
   <depend>rosidl_typesupport_introspection_cpp</depend>
-  <build_depend>action_tutorials_interfaces</build_depend>
+  <build_depend>example_interfaces</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>example_interfaces</test_depend>
-  <test_depend>geometry_msgs</test_depend>
   <test_depend>ros_babel_fish_test_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ros_babel_fish/package.xml
+++ b/ros_babel_fish/package.xml
@@ -28,6 +28,7 @@
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>geometry_msgs</test_depend>
   <test_depend>ros_babel_fish_test_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
 

--- a/ros_babel_fish/src/detail/babel_fish_service.cpp
+++ b/ros_babel_fish/src/detail/babel_fish_service.cpp
@@ -43,8 +43,9 @@ BabelFishService::BabelFishService( std::shared_ptr<rcl_node_t> node_base,
 
     rclcpp::exceptions::throw_from_rcl_error( ret, "could not create service" );
   }
-  TRACEPOINT( rclcpp_service_callback_added, static_cast<const void *>( get_service_handle().get() ),
-              static_cast<const void *>( &callback_ ) );
+  TRACETOOLS_TRACEPOINT( rclcpp_service_callback_added,
+                         static_cast<const void *>( get_service_handle().get() ),
+                         static_cast<const void *>( &callback_ ) );
 #ifndef TRACETOOLS_DISABLED
   callback_.register_callback_for_tracing();
 #endif

--- a/ros_babel_fish/src/detail/babel_fish_subscription.cpp
+++ b/ros_babel_fish/src/detail/babel_fish_subscription.cpp
@@ -33,10 +33,11 @@ BabelFishSubscription::BabelFishSubscription(
     this->subscription_topic_statistics_ = std::move( subscription_topic_statistics );
   }
 
-  TRACEPOINT( rclcpp_subscription_init, static_cast<const void *>( get_subscription_handle().get() ),
-              static_cast<const void *>( this ) );
-  TRACEPOINT( rclcpp_subscription_callback_added, static_cast<const void *>( this ),
-              static_cast<const void *>( &callback_ ) );
+  TRACETOOLS_TRACEPOINT( rclcpp_subscription_init,
+                         static_cast<const void *>( get_subscription_handle().get() ),
+                         static_cast<const void *>( this ) );
+  TRACETOOLS_TRACEPOINT( rclcpp_subscription_callback_added, static_cast<const void *>( this ),
+                         static_cast<const void *>( &callback_ ) );
   // The callback object gets copied, so if registration is done too early/before this point
   // (e.g. in `AnySubscriptionCallback::set()`), its address won't match any address used later
   // in subsequent tracepoints.

--- a/ros_babel_fish/test/action_client.cpp
+++ b/ros_babel_fish/test/action_client.cpp
@@ -6,7 +6,7 @@
 #include <ros_babel_fish/babel_fish.hpp>
 
 #include <action_msgs/msg/goal_status_array.h>
-#include <action_tutorials_interfaces/action/fibonacci.hpp>
+#include <example_interfaces/action/fibonacci.hpp>
 #include <ros_babel_fish_test_msgs/action/simple_test.hpp>
 
 #include <rclcpp/rclcpp.hpp>
@@ -49,7 +49,7 @@ TEST( ActionClientTest, actionLookup )
   EXPECT_NE( ts, nullptr );
   EXPECT_TRUE( Equal( type_support->type_support_handle, *ts ) );
 
-  type_support = fish.get_action_type_support( "action_tutorials_interfaces/action/Fibonacci" );
+  type_support = fish.get_action_type_support( "example_interfaces/action/Fibonacci" );
   ASSERT_NE( type_support, nullptr );
 
   const auto *ts_map =


### PR DESCRIPTION
ROS 2 Rolling has made two changes that cause this package to not build in its current form:

1. The TRACEPOINT macro has been renamed to TRACETOOLS_TRACEPOINT.
2. The action_tutorials_interface package has been removed, since it was duplicating an action that was already available in example_interfaces.

This commit fixes both of these issues.

This PR is currently targeted at the `jazzy` branch, but I don't think we should merge it there; it will break the build on Jazzy.  Instead, I suggest creating a `rolling` branch here, and then retargeting this PR to the `rolling` branch.

Once this is merged and released, this should fix the failing build as seen in https://build.ros2.org/view/Rbin_rhel_el964/job/Rbin_rhel_el964__ros_babel_fish__rhel_9_x86_64__binary/10/console

@nuclearsandwich FYI