### PR TITLE
Add a deserialize method to Subscription

### DIFF
--- a/ros_babel_fish/include/ros_babel_fish/detail/babel_fish_subscription.hpp
+++ b/ros_babel_fish/include/ros_babel_fish/detail/babel_fish_subscription.hpp
@@ -71,6 +71,8 @@ public:
   void handle_dynamic_message( const rclcpp::dynamic_typesupport::DynamicMessage::SharedPtr &message,
                                const rclcpp::MessageInfo &message_info ) override;
 
+  bool deserialize( const rclcpp::SerializedMessage &serialized, CompoundMessage &out ) const;
+
 private:
   RCLCPP_DISABLE_COPY( BabelFishSubscription )
 

--- a/ros_babel_fish/src/detail/babel_fish_subscription.cpp
+++ b/ros_babel_fish/src/detail/babel_fish_subscription.cpp
@@ -142,7 +142,13 @@ bool BabelFishSubscription::deserialize( const rclcpp::SerializedMessage &serial
   }
 
   rclcpp::SerializationBase serializer( &type_support_->type_support_handle );
-  serializer.deserialize_message( &serialized, type_erased.get() );
+  try {
+    serializer.deserialize_message( &serialized, type_erased.get() );
+  } catch ( const std::exception &e ) {
+    RBF2_ERROR_STREAM( "Failed to deserialize message of type '" << type_support_->name
+                                                                 << "': " << e.what() );
+    return false;
+  }
   out = CompoundMessage( *type_support_, std::move( type_erased ) );
   return true;
 }

--- a/ros_babel_fish/src/detail/babel_fish_subscription.cpp
+++ b/ros_babel_fish/src/detail/babel_fish_subscription.cpp
@@ -8,6 +8,7 @@
 
 #include <rcl/rcl.h>
 #include <rclcpp/node.hpp>
+#include <rclcpp/serialization.hpp>
 
 namespace ros_babel_fish
 {
@@ -131,6 +132,20 @@ MessageTypeSupport::ConstSharedPtr BabelFishSubscription::get_message_type_suppo
 }
 
 std::string BabelFishSubscription::get_message_type() const { return type_support_->name; }
+
+bool BabelFishSubscription::deserialize( const rclcpp::SerializedMessage &serialized,
+                                         CompoundMessage &out ) const
+{
+  auto type_erased = createContainer( *type_support_ );
+  if ( !type_erased ) {
+    return false;
+  }
+
+  rclcpp::SerializationBase serializer( &type_support_->type_support_handle );
+  serializer.deserialize_message( &serialized, type_erased.get() );
+  out = CompoundMessage( *type_support_, std::move( type_erased ) );
+  return true;
+}
 
 rclcpp::dynamic_typesupport::DynamicMessageType::SharedPtr
 BabelFishSubscription::get_shared_dynamic_message_type()

--- a/ros_babel_fish/test/message_decoding.cpp
+++ b/ros_babel_fish/test/message_decoding.cpp
@@ -274,6 +274,33 @@ TEST_F( MessageDecodingTest, arrayTests )
   ASSERT_EQ( test_array.uint16s[4], msg_uint16s[4] );
 }
 
+TEST_F( MessageDecodingTest, deserializeSerializedMessage )
+{
+  using namespace std::chrono_literals;
+  rclcpp::GuardCondition::SharedPtr cond = std::make_shared<rclcpp::GuardCondition>();
+  rclcpp::WaitSet set;
+  set.add_guard_condition( cond );
+
+  std::shared_ptr<rclcpp::SerializedMessage> serialized_message;
+  auto subscription = fish.create_subscription(
+      *node, "/test_message_decoding/test_message", 1,
+      std::function<void( std::shared_ptr<rclcpp::SerializedMessage> )>(
+          [&serialized_message, &cond]( std::shared_ptr<rclcpp::SerializedMessage> msg ) {
+            serialized_message = std::move( msg );
+            cond->trigger();
+          } ) );
+  ASSERT_NE( subscription, nullptr );
+  ASSERT_EQ( set.wait( 5s ).kind(), rclcpp::WaitResultKind::Ready );
+  ASSERT_NE( serialized_message, nullptr );
+
+  CompoundMessage result;
+  ASSERT_TRUE( subscription->deserialize( *serialized_message, result ) );
+
+  ASSERT_TRUE( result.isValid() );
+  ASSERT_EQ( result.name(), "ros_babel_fish_test_msgs/msg/TestMessage" );
+  EXPECT_TRUE( MESSAGE_CONTENT_EQUAL( test_message, result ) );
+}
+
 int main( int argc, char **argv )
 {
   testing::InitGoogleTest( &argc, argv );


### PR DESCRIPTION
This enables users to use a SerializedMessage callback and deserialize later.

Not ABI breaking, so can be backported.

My use case is bandwidth monitoring, so I know the size of the message that was transmitted and can add monitoring to [qml6_ros2_plugin](https://github.com/StefanFabian/qml6_ros2_plugin) and [rqml](https://github.com/StefanFabian/rqml).